### PR TITLE
Updated examples to set CS on D20

### DIFF
--- a/examples/example1_basic_lightning_spi.py
+++ b/examples/example1_basic_lightning_spi.py
@@ -47,8 +47,9 @@ as3935_interrupt_pin.pull = digitalio.Pull.DOWN
 # Create a library object using the Bus SPI port
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 
-# Set up chip select (CE0 is labeled CS on Sparkfun Pi Hat)
-cs = digitalio.DigitalInOut(board.CE0)
+# Set up chip select on D20
+# CS can be any available GPIO pin
+cs = digitalio.DigitalInOut(board.D20)
 cs.direction = digitalio.Direction.OUTPUT
 
 lightning = sparkfun_qwiicas3935.Sparkfun_QwiicAS3935_SPI(spi, cs)

--- a/examples/example2_more_lightning_features_spi.py
+++ b/examples/example2_more_lightning_features_spi.py
@@ -40,8 +40,9 @@ as3935_interrupt_pin.pull = digitalio.Pull.DOWN
 # Create a library object using the Bus SPI port
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 
-# Set up chip select (CE0 is labeled CS on Sparkfun Pi Hat)
-cs = digitalio.DigitalInOut(board.CE0)
+# Set up chip select on D20
+# CS can be any available GPIO pin
+cs = digitalio.DigitalInOut(board.D20)
 cs.direction = digitalio.Direction.OUTPUT
 
 lightning = sparkfun_qwiicas3935.Sparkfun_QwiicAS3935_SPI(spi, cs)

--- a/examples/example3_tune_antenna_spi.py
+++ b/examples/example3_tune_antenna_spi.py
@@ -31,8 +31,9 @@ import sparkfun_qwiicas3935
 # Create a library object using the Bus SPI port
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 
-# Set up chip select (CE0 is labeled CS on Sparkfun Pi Hat)
-cs = digitalio.DigitalInOut(board.CE0)
+# Set up chip select on D20
+# CS can be any available GPIO pin
+cs = digitalio.DigitalInOut(board.D20)
 cs.direction = digitalio.Direction.OUTPUT
 
 lightning = sparkfun_qwiicas3935.Sparkfun_QwiicAS3935_SPI(spi, cs)

--- a/examples/qwiicas3935_simpletest.py
+++ b/examples/qwiicas3935_simpletest.py
@@ -17,6 +17,9 @@
  that status of the Qwiic AS3935 Lightning Detector.
 """
 import sys
+
+# import busio
+# import digitalio
 import board
 import sparkfun_qwiicas3935
 
@@ -27,8 +30,11 @@ i2c = board.I2C()
 lightning = sparkfun_qwiicas3935.Sparkfun_QwiicAS3935_I2C(i2c)
 
 # OR create a library object using the Bus SPI port
+# CS can be any available GPIO pin
+
 # spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
-# cs = digitalio.DigitalInOut(board.D8)
+# cs = digitalio.DigitalInOut(board.D20)
+# cs.direction = digitalio.Direction.OUTPUT
 # lightning = sparkfun_qwiicas3935.Sparkfun_QwiicAS3935_SPI(spi, cs)
 
 # Check if connected


### PR DESCRIPTION
Updated SPI examples to set CS on D20 with a comment that CS can be on any available GPIO pin.